### PR TITLE
Read themes from Settings Editor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = true

--- a/xfce4-night-mode-redshift.sh
+++ b/xfce4-night-mode-redshift.sh
@@ -14,4 +14,4 @@ fi
 echo '<tool>
   Night mode defined by RedShift
   Click to toggle mode for a while
-  </tool>'
+</tool>'


### PR DESCRIPTION
Instead of depending on a `-dark` suffix (or `-Dark` with @zacharyburnett's pull request #2) this now allows you to set light and dark themes (Gtk, icons, cursors and window manager) in Settings Editor > night-mode

Please check my code thoroughly; I'm not a Bash programmer by trade.

(I also added an `.editorconfig` to make sure my IDE maintained the 2 space indent.)