### PR TITLE
Set GTK theme

### DIFF
--- a/xfce4-night-mode.sh
+++ b/xfce4-night-mode.sh
@@ -71,6 +71,11 @@ function set_theme()
     show_usage
     exit 1
   fi
+
+  if [ "$2" = "/Net/ThemeName" ]
+  then
+    gsettings set org.gnome.desktop.interface gtk-theme "$target_theme"
+  fi
 }
 
 function get_config()


### PR DESCRIPTION
Some apps don't react to automatic theme changes via `xfconf-query`
because they instead monitor the `gtk-theme` setting - Sublime Text is a
good example. This quick fix additionally sets the `gtk-theme` `gsetting`
to the target theme so these kind of apps will respond to theme
changes.