### PR TITLE
Handle Xfce panel Dark-mode and also extra bash command

### DIFF
--- a/xfce4-night-mode.sh
+++ b/xfce4-night-mode.sh
@@ -105,6 +105,8 @@ CURSOR_LIGHT="$(get_config 'Light/CursorTheme' 'string' $(xfconf-query --channel
 CURSOR_DARK="$(get_config 'Dark/CursorTheme' 'string' $(xfconf-query --channel xsettings --property /Gtk/CursorThemeName))"
 WM_LIGHT="$(get_config 'Light/WindowManagerTheme' 'string' $(xfconf-query --channel xfwm4 --property /general/theme))"
 WM_DARK="$(get_config 'Dark/WindowManagerTheme' 'string' $(xfconf-query --channel xfwm4 --property /general/theme))"
+EXTRACMD_LIGHT="$(get_config 'Light/ExtraCmd' 'string')"
+EXTRACMD_DARK="$(get_config 'Dark/ExtraCmd' 'string')"
 
 mode="$(parse_args $@)"
 
@@ -149,6 +151,12 @@ set_theme 'xsettings' '/Gtk/CursorThemeName' "CURSOR_$suffix"
 
 # Window manager theme
 set_theme 'xfwm4' '/general/theme' "WM_$suffix"
+
+# Extra command (i.e kvantummanager etc.)
+cmd="EXTRACMD_$suffix"
+if [ ! -z "${!cmd}" ]; then
+  eval "${!cmd}"
+fi
 
 set_config 'active' 'string' "$mode"
 

--- a/xfce4-night-mode.sh
+++ b/xfce4-night-mode.sh
@@ -105,6 +105,8 @@ CURSOR_LIGHT="$(get_config 'Light/CursorTheme' 'string' $(xfconf-query --channel
 CURSOR_DARK="$(get_config 'Dark/CursorTheme' 'string' $(xfconf-query --channel xsettings --property /Gtk/CursorThemeName))"
 WM_LIGHT="$(get_config 'Light/WindowManagerTheme' 'string' $(xfconf-query --channel xfwm4 --property /general/theme))"
 WM_DARK="$(get_config 'Dark/WindowManagerTheme' 'string' $(xfconf-query --channel xfwm4 --property /general/theme))"
+PANELS_LIGHT="$(get_config 'Light/PanelsDarkMode' 'bool' $(xfconf-query --channel xfce4-panel --property /panels/dark-mode))"
+PANELS_DARK="$(get_config 'Dark/PanelsDarkMode' 'bool' $(xfconf-query --channel xfce4-panel --property /panels/dark-mode))"
 
 mode="$(parse_args $@)"
 
@@ -150,6 +152,9 @@ set_theme 'xsettings' '/Gtk/CursorThemeName' "CURSOR_$suffix"
 # Window manager theme
 set_theme 'xfwm4' '/general/theme' "WM_$suffix"
 
+# Panel
+set_theme 'xfce4-panel' '/panels/dark-mode' "PANELS_$suffix"
+
 set_config 'active' 'string' "$mode"
 
 echo "<txt>$TEXT</txt>"
@@ -166,4 +171,5 @@ echo "<tool>
   * Icon theme: \`xsettings/Net/IconThemeName\`
   * Cursor theme: \`xsettings/Gtk/CursorThemeName\`
   * Window manager theme: \`xfwm4/general/theme\`
+  * Panels dark-mode: \`xfce4-panel/panels/dark-mode\`
 </tool>"


### PR DESCRIPTION
I propose a commit from the fork I made from this project.
On my repository I added two branches for modifications :
* one for panel dark-mode in Xfce (panel)
* one to handle extra bash command in case you wish execute commands for other gui toolkit (extracmd). For example on manjaro when switching to light theme I execute the following command : 
```
$ kvantummanager --set Matcha-Light
```
and conversely for dark-theme
```
$ kvantummanager --set Matcha-Dark
```
Purpose of these command is to make some Qt apps theme match the GTK Xfce theme (Manjaro kernel manager for example).

I merged these two branches in my own master branch, then now suggest to merge my master branch in your project.