### PR TITLE
Handle redshift transition period

### DIFF
--- a/xfce4-night-mode-redshift.sh
+++ b/xfce4-night-mode-redshift.sh
@@ -4,11 +4,37 @@
 # https://gitlab.com/bimlas/xfce4-night-mode (main repository)
 # https://github.com/bimlas/xfce4-night-mode (mirror, please star if you like the plugin)
 
-if ( LC_ALL='C' redshift -p 2> /dev/null | grep 'Period: Night' > /dev/null ); then
-  mode='night'
-else
-  mode='day'
-fi
+# Change this variable to define which mode to use while RedShift transitions from day to night or vice versa
+# Choices: night|day
+TRANSITION_MODE='night'
+
+redshift_period=$( LC_ALL='C' redshift -p 2> /dev/null | grep -E '^Period: ' | grep -Eo '(Transition|Night|Day)' )
+
+case $redshift_period in
+  "Day")
+    mode='day'
+    ;;
+
+  "Night")
+    mode='night'
+    ;;
+
+  "Transition")
+    if [ $TRANSITION_MODE ]; then
+      if [[ $TRANSITION_MODE =~ (day|night) ]]; then
+        mode=$TRANSITION_MODE
+      else
+        echo 'Invalid value set for $TRANSITION_MODE!'
+      fi
+    else
+      echo 'RedShift transition period detected but $TRANSITION_MODE is not set. Set $TRANSITION_MODE to define which mode to use during transition periods.'
+    fi
+    ;;
+
+  *)
+    echo "Could not determine RedShift period: $redshift_period"
+    ;;
+esac
 
 "$(dirname "$0")/xfce4-night-mode.sh" "$mode" | sed '/<tool>/,/<\/tool>/ d'
 echo '<tool>


### PR DESCRIPTION
Redshift offers a third period `Transition` which is active while transitioning between `Day` and `Night`.

`xfce4-night-mode-redshift.sh` currently  does not recognize this and moves to / stays in `day` mode because `grep 'Period: Night'` does not match on `Period: Transition`.

With this PR the script handles all three periods and allows the user to define which mode to use during transition periods with a variable `TRANSITION_MODE`. My use case is switching to night mode during the transition period at sunset so I set the default to `night`.

Thank you for the great work! It has really improved my XFCE experience :tada: 